### PR TITLE
tested base to base conversion for hex octet decimal and binary

### DIFF
--- a/python/num_conv.py
+++ b/python/num_conv.py
@@ -1,30 +1,56 @@
 import argparse
+import numpy
 
 class converter():
     def __init__(self) -> None:
         self.d = " "
-        self.prefix =  ""
+        self.inPrefix =  ""
+        self.outDel = ""
+        self.outPrefix = ""
+        self.inBase = 10
+        self.outBase = 10
+
+    def __str__(self) -> str:
+        s = f"{self.__dict__}"
+        return s
         
+    def stripPrefix(self, s:str):
+        val = None
+        if self.inPrefix in s: 
+            val = s.split(self.inPrefix)
+            if len(val) == 1:
+                val = val[0]
+            else :
+                val = val[1]
+        else : 
+            val = s
+        return val
+
+    def formatOutput(self, num:list) -> str:
+        s = ""
+        first=True
+        for i in num:
+            if not first:
+                s += f"{self.outDel}{self.outPrefix}{i}"
+            else :
+                s += f"{self.outPrefix}{i}"
+                first = False
+
+        return s
 
     def b2h(self, s: str):
         s = str(s)
         # print(f"input : {s}")
         numList = s.split(self.d)
+        outNumList = []
         h = ""
         for i in numList:
             if len(str(i)) > 0:
                 # print(f"i : {i}")
-                val = None
-                if self.prefix in str(i): 
-                    val = str(i).split(self.prefix)
-                    if len(val) == 1:
-                        val = val[0]
-                    else :
-                        val = val[1]
-                else : 
-                    val = str(i)
+                val = self.stripPrefix(str(i))
                 num = int(str(val), 2)
-                h += f" {hex(num)[2:]}"
+                outNumList.append(hex(num)[2:])
+        h += self.formatOutput(outNumList)
         print(f"hex output : {h}")
         return h
 
@@ -33,12 +59,15 @@ class converter():
         s = str(s)
         # print(f"input : {s}")
         numList = s.split(self.d)
+        outNumList = []
         d = ""
         for i in numList:
             if len(str(i)) > 0:
                 # print(f"i : {i}")
-                num = int(i, 2)
-                d += f" {int(num)}"
+                val = self.stripPrefix(str(i))
+                num = int(val, 2)
+                outNumList.append(int(num))
+        d += self.formatOutput(outNumList)
         print(f"decimal output : {d}")
         return d
 
@@ -46,15 +75,39 @@ class converter():
     def h2b(self, s: str):
         numList = s.split(self.d)
         b = ""
+        outNumList = []
         for i in numList:
             if len(i) > 0:
-                num = int(i, 16)
-                b += " {0:b}".format(num)
+                val = self.stripPrefix(str(i))
+                num = int(val, 16)
+                outNumList.append("{0:b}".format(num))
+        b += self.formatOutput(outNumList)
         print(f"binary output : {b}")
         return b
 
+    def conv(self, inBase:int , outBase:int , input:str) -> str:
+        output = ""
+        numList = input.split(self.d)
+        intList = []
+        outNumList = []
+        for i in numList:
+            if len(i) > 0:
+                val = self.stripPrefix(str(i))
+                num = int(val , inBase)
+                intList.append(num)
+                numStr = numpy.base_repr(num , outBase , padding=0)
+                outNumList.append(numStr)
+        output += self.formatOutput(outNumList)
+        print(f"numbers : {intList} \nOutput : {output}\n")
+        return output
 
-def configParser():
+def getArg(args, arg:str , default) :
+    val = getattr(args , arg)
+    if val == None:
+        val = default
+    return val
+
+def configParser(conv:converter):
     parser = argparse.ArgumentParser(description="This is default arg parser")
     parser.add_argument(
         "--func", type=str, required=False, help="Function name to be used for parsing")
@@ -63,17 +116,31 @@ def configParser():
     parser.add_argument(
         "-d", type=str, required=False, help="Delimeter")
     parser.add_argument(
-        "--prefix", type=str, required=False, help="Prefix of each number")
+        "--in-prefix", type=str, required=False, help="Prefix of each number in the input")
+    parser.add_argument(
+        "--out-prefix", type=str, required=False, help="Prefix of each number in the output")
+    parser.add_argument(
+        "--out-delimeter", type=str, required=False, help="Delimeter in the output")
+    parser.add_argument(
+        "--in-base", type=str, required=False, help="Base of input (0-36)")
+    parser.add_argument(
+        "--out-base", type=str, required=False, help="Base of output (0-36)")
     args = parser.parse_args()
+    conv.d = getattr(args, "d" , " ")
+    conv.inPrefix = getArg(args, "in_prefix" , " ")
+    conv.outPrefix = getArg(args, "out_prefix" , " ")
+    conv.outDel = getattr(args, "out_delimeter" , "")
+    conv.inBase = int(getArg(args, "in_base" , 10))
+    conv.outBase = int(getArg(args, "out_base" , 10))
+    print( f"argparse : conv : {conv} \n" )
     return args
 
 def main():
-    args = configParser()
-    print(f"args :  {args}")
     conv = converter()
-    conv.d = args.d
-    conv.prefix = args.prefix
-    getattr(conv , args.func)(args.s)
+    args = configParser(conv)
+    print(f"args :  {args} , conv : {conv} \n")
+    # getattr(conv , args.func)(args.s)
+    conv.conv(inBase=conv.inBase , outBase=conv.outBase , input=args.s)
     return
 
 


### PR DESCRIPTION
Output : 

```
#19:21|scripts|>> python3 python/num_conv.py  -d " " --out-delimeter="," --in-base=10 --out-base="16"  --out-prefix="0x" --s "165 170 255 1024"
argparse : conv : {'d': ' ', 'inPrefix': ' ', 'outDel': ',', 'outPrefix': '0x', 'inBase': 10, 'outBase': 16} 

args :  Namespace(d=' ', func=None, in_base='10', in_prefix=None, out_base='16', out_delimeter=',', out_prefix='0x', s='165 170 255 1024') , conv : {'d': ' ', 'inPrefix': ' ', 'outDel': ',', 'outPrefix': '0x', 'inBase': 10, 'outBase': 16} 

numbers : [165, 170, 255, 1024] 
Output : 0xA5,0xAA,0xFF,0x400

#19:21|scripts|>> python3 python/num_conv.py  -d " " --out-delimeter="," --in-base=10 --out-base="2"  --out-prefix="0b" --s "165 170 255 1024"
argparse : conv : {'d': ' ', 'inPrefix': ' ', 'outDel': ',', 'outPrefix': '0b', 'inBase': 10, 'outBase': 2} 

args :  Namespace(d=' ', func=None, in_base='10', in_prefix=None, out_base='2', out_delimeter=',', out_prefix='0b', s='165 170 255 1024') , conv : {'d': ' ', 'inPrefix': ' ', 'outDel': ',', 'outPrefix': '0b', 'inBase': 10, 'outBase': 2} 

numbers : [165, 170, 255, 1024] 
Output : 0b10100101,0b10101010,0b11111111,0b10000000000

#19:21|scripts|>> python3 python/num_conv.py  -d " " --out-delimeter="," --in-base=10 --out-base="21"  --out-prefix="_|" --s "165 170 255 1024"
argparse : conv : {'d': ' ', 'inPrefix': ' ', 'outDel': ',', 'outPrefix': '_|', 'inBase': 10, 'outBase': 21} 

args :  Namespace(d=' ', func=None, in_base='10', in_prefix=None, out_base='21', out_delimeter=',', out_prefix='_|', s='165 170 255 1024') , conv : {'d': ' ', 'inPrefix': ' ', 'outDel': ',', 'outPrefix': '_|', 'inBase': 10, 'outBase': 21} 

numbers : [165, 170, 255, 1024] 
Output : _|7I,_|82,_|C3,_|26G

#19:21|scripts|>> 

```